### PR TITLE
Node reference id bug fix

### DIFF
--- a/goastgen/libgoastgen_array_test.go
+++ b/goastgen/libgoastgen_array_test.go
@@ -6,38 +6,49 @@ import (
 )
 
 func TestArrayWithnillPointerCheck(t *testing.T) {
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	var nilStr *string
 	var nilObj *Phone
 	var nilMap *map[string]Phone
 	arrayWithnil := [4]interface{}{"valid string", nilStr, nilObj, nilMap}
-	result := processArrayOrSlice(arrayWithnil, nil)
+	result := processArrayOrSlice(arrayWithnil, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := []interface{}{"valid string"}
 
 	assert.Equal(t, expectedResult, result, "It should process valid values of the array successfully")
 }
 
 func TestSimpleInterfaceWithArray(t *testing.T) {
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	arrayType := [2]interface{}{"first", "second"}
-	result := processArrayOrSlice(arrayType, nil)
+	result := processArrayOrSlice(arrayType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := []interface{}{"first", "second"}
 	assert.Equal(t, expectedResult, result, "Array of interface containing string pointers should match with expected results")
 }
 
 func TestSimpleInterfaceWithArrayOfPointersType(t *testing.T) {
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	first := "first"
 	second := "second"
 	arrayType := [2]interface{}{&first, &second}
-	result := processArrayOrSlice(arrayType, nil)
+	result := processArrayOrSlice(arrayType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := []interface{}{"first", "second"}
 	assert.Equal(t, expectedResult, result, "Array of interface containing string pointers should match with expected results")
 }
 
 func TestObjectInterfaceWithArrayOfPointers(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	phone1 := Phone{PhoneNo: "1234567890", Type: "Home"}
 	phone2 := Phone{PhoneNo: "0987654321", Type: "Office"}
 	arrayType := [2]interface{}{&phone1, &phone2}
-	result := processArrayOrSlice(arrayType, nil)
+	result := processArrayOrSlice(arrayType, nil, &lastNodeId, nodeAddressMap)
 	firstPhoneItem := make(map[string]interface{})
 	firstPhoneItem["PhoneNo"] = "1234567890"
 	firstPhoneItem["Type"] = "Home"
@@ -53,11 +64,13 @@ func TestObjectInterfaceWithArrayOfPointers(t *testing.T) {
 }
 
 func TestSliceObjctPtrType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	phone1 := Phone{PhoneNo: "1234567890", Type: "Home"}
 	phone2 := Phone{PhoneNo: "0987654321", Type: "Office"}
 	objArrayType := SliceObjPtrType{Id: 20, PhoneList: []*Phone{&phone1, &phone2}}
-	result := serilizeToMap(objArrayType, nil)
+	result := serilizeToMap(objArrayType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 20
 	expectedResult["node_type"] = "goastgen.SliceObjPtrType"
@@ -78,12 +91,14 @@ func TestSliceObjctPtrType(t *testing.T) {
 }
 
 func TestArrayPtrType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	firstStr := "First"
 	secondStr := "Second"
 	thirdStr := "Third"
 	arrayType := ArrayPtrType{Id: 10, NameList: [3]*string{&firstStr, &secondStr, &thirdStr}}
-	result := serilizeToMap(arrayType, nil)
+	result := serilizeToMap(arrayType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 10
 	expectedResult["node_type"] = "goastgen.ArrayPtrType"
@@ -94,9 +109,11 @@ func TestArrayPtrType(t *testing.T) {
 }
 
 func TestObjectSliceType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	objArrayType := ObjectSliceType{Id: 20, PhoneList: []Phone{{PhoneNo: "1234567890", Type: "Home"}, {PhoneNo: "0987654321", Type: "Office"}}}
-	result := serilizeToMap(objArrayType, nil)
+	result := serilizeToMap(objArrayType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 20
 	expectedResult["node_type"] = "goastgen.ObjectSliceType"
@@ -117,9 +134,11 @@ func TestObjectSliceType(t *testing.T) {
 }
 
 func TestArrayType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	arrayType := ArrayType{Id: 10, NameList: [3]string{"First", "Second", "Third"}}
-	result := serilizeToMap(arrayType, nil)
+	result := serilizeToMap(arrayType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 10
 	expectedResult["NameList"] = []interface{}{"First", "Second", "Third"}
@@ -129,9 +148,10 @@ func TestArrayType(t *testing.T) {
 }
 
 func TestSliceType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 	arrayType := SliceType{Id: 10, NameList: []string{"First", "Second"}}
-	result := serilizeToMap(arrayType, nil)
+	result := serilizeToMap(arrayType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 10
 	expectedResult["NameList"] = []interface{}{"First", "Second"}
@@ -141,13 +161,14 @@ func TestSliceType(t *testing.T) {
 }
 
 func TestSimpleArrayType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 
 	phone1 := Phone{PhoneNo: "1234567890", Type: "Home"}
 	phone2 := Phone{PhoneNo: "0987654321", Type: "Office"}
 	simplePtrStr := "Simple PTR String"
 	arrayType := []interface{}{&phone1, phone2, "Simple String", 90, &simplePtrStr}
-	result := serilizeToMap(arrayType, nil)
+	result := serilizeToMap(arrayType, nil, &lastNodeId, nodeAddressMap)
 
 	firstPhone := make(map[string]interface{})
 	firstPhone["PhoneNo"] = "1234567890"

--- a/goastgen/libgoastgen_ast_test.go
+++ b/goastgen/libgoastgen_ast_test.go
@@ -13,10 +13,12 @@ type RecursivePtrType struct {
 }
 
 func TestRecursivePointerCheck(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	recursivePtrType := RecursivePtrType{Id: 10, Name: "Gajraj"}
 	recursivePtrType.NodePtr = &recursivePtrType
-	result := serilizeToMap(&recursivePtrType, nil)
+	result := serilizeToMap(&recursivePtrType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 10
 	expectedResult["Name"] = "Gajraj"

--- a/goastgen/libgoastgen_map_test.go
+++ b/goastgen/libgoastgen_map_test.go
@@ -6,6 +6,9 @@ import (
 )
 
 func TestMapWithNilPointerCheck(t *testing.T) {
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	var nilStr *string
 	var nilObj *Phone
 	mapType := make(map[string]interface{})
@@ -13,7 +16,7 @@ func TestMapWithNilPointerCheck(t *testing.T) {
 	mapType["second"] = nilStr
 	mapType["third"] = nilObj
 
-	result := processMap(mapType, nil)
+	result := processMap(mapType, nil, &lastNodeId, nodeAddressMap)
 
 	expectedResult := make(map[string]interface{})
 	expectedResult["first"] = "first value"
@@ -23,7 +26,8 @@ func TestMapWithNilPointerCheck(t *testing.T) {
 }
 
 func TestArrayOfPointerOfMapOfObjectPointerType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 
 	first := Phone{PhoneNo: "1234567890", Type: "Home"}
 	second := Phone{PhoneNo: "0987654321", Type: "Office"}
@@ -36,7 +40,7 @@ func TestArrayOfPointerOfMapOfObjectPointerType(t *testing.T) {
 	secondMap["smfirst"] = &third
 	secondMap["smsecond"] = &forth
 	array := [2]*map[string]*Phone{&firstMap, &secondMap}
-	result := processArrayOrSlice(array, nil)
+	result := processArrayOrSlice(array, nil, &lastNodeId, nodeAddressMap)
 	firstPhone := make(map[string]interface{})
 	firstPhone["PhoneNo"] = "1234567890"
 	firstPhone["Type"] = "Home"
@@ -69,6 +73,9 @@ func TestArrayOfPointerOfMapOfObjectPointerType(t *testing.T) {
 }
 
 func TestArrayOfPointerOfMapOfPrimitivesType(t *testing.T) {
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	firstMap := make(map[string]string)
 	firstMap["fmfirst"] = "fmfirstvalue"
 	firstMap["fmsecond"] = "fmsecondvalue"
@@ -76,7 +83,7 @@ func TestArrayOfPointerOfMapOfPrimitivesType(t *testing.T) {
 	secondMap["smfirst"] = "smfirstvalue"
 	secondMap["smsecond"] = "smsecondvalue"
 	array := [2]*map[string]string{&firstMap, &secondMap}
-	result := processArrayOrSlice(array, nil)
+	result := processArrayOrSlice(array, nil, &lastNodeId, nodeAddressMap)
 
 	firstExpectedMap := make(map[string]interface{})
 	firstExpectedMap["fmfirst"] = "fmfirstvalue"
@@ -90,6 +97,9 @@ func TestArrayOfPointerOfMapOfPrimitivesType(t *testing.T) {
 }
 
 func TestArrayOfMapOfPrimitivesType(t *testing.T) {
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	firstMap := make(map[string]string)
 	firstMap["fmfirst"] = "fmfirstvalue"
 	firstMap["fmsecond"] = "fmsecondvalue"
@@ -97,7 +107,7 @@ func TestArrayOfMapOfPrimitivesType(t *testing.T) {
 	secondMap["smfirst"] = "smfirstvalue"
 	secondMap["smsecond"] = "smsecondvalue"
 	array := [2]map[string]string{firstMap, secondMap}
-	result := processArrayOrSlice(array, nil)
+	result := processArrayOrSlice(array, nil, &lastNodeId, nodeAddressMap)
 
 	firstExpectedMap := make(map[string]interface{})
 	firstExpectedMap["fmfirst"] = "fmfirstvalue"
@@ -112,7 +122,9 @@ func TestArrayOfMapOfPrimitivesType(t *testing.T) {
 }
 
 func TestMapObjPtrType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	first := Phone{PhoneNo: "1234567890", Type: "Home"}
 	second := Phone{PhoneNo: "0987654321", Type: "Office"}
 	phones := make(map[string]*Phone)
@@ -120,7 +132,7 @@ func TestMapObjPtrType(t *testing.T) {
 	phones["second"] = &second
 
 	mapType := MapObjPtrType{Id: 90, Phones: phones}
-	result := serilizeToMap(mapType, nil)
+	result := serilizeToMap(mapType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 90
 	expectedResult["node_type"] = "goastgen.MapObjPtrType"
@@ -145,14 +157,16 @@ func TestMapObjPtrType(t *testing.T) {
 }
 
 func TestMapStrPtrType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	first := "firstvalue"
 	second := "secondvalue"
 	names := make(map[string]*string)
 	names["firstname"] = &first
 	names["secondname"] = &second
 	mapType := MapStrPtrType{Id: 30, Names: names}
-	result := serilizeToMap(mapType, nil)
+	result := serilizeToMap(mapType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 30
 	expectedResult["node_type"] = "goastgen.MapStrPtrType"
@@ -166,13 +180,15 @@ func TestMapStrPtrType(t *testing.T) {
 }
 
 func TestMapObjType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	phones := make(map[string]Phone)
 	phones["first"] = Phone{PhoneNo: "1234567890", Type: "Home"}
 	phones["second"] = Phone{PhoneNo: "0987654321", Type: "Office"}
 
 	mapType := MapObjType{Id: 90, Phones: phones}
-	result := serilizeToMap(mapType, nil)
+	result := serilizeToMap(mapType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 90
 	expectedResult["node_type"] = "goastgen.MapObjType"
@@ -196,12 +212,14 @@ func TestMapObjType(t *testing.T) {
 }
 
 func TestMapIntType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	names := make(map[string]int)
 	names["firstname"] = 1000
 	names["secondname"] = 2000
 	mapType := MapIntType{Id: 30, Names: names}
-	result := serilizeToMap(mapType, nil)
+	result := serilizeToMap(mapType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 30
 	expectedResult["node_type"] = "goastgen.MapIntType"
@@ -215,12 +233,14 @@ func TestMapIntType(t *testing.T) {
 }
 
 func TestMapType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	names := make(map[string]string)
 	names["firstname"] = "firstvalue"
 	names["secondname"] = "secondvalue"
 	mapType := MapType{Id: 30, Names: names}
-	result := serilizeToMap(mapType, nil)
+	result := serilizeToMap(mapType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 30
 	expectedResult["node_type"] = "goastgen.MapType"
@@ -233,7 +253,9 @@ func TestMapType(t *testing.T) {
 }
 
 func TestSimpleMapType(t *testing.T) {
-	lastNodeId = 1
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+
 	phone1 := Phone{PhoneNo: "1234567890", Type: "Home"}
 	phone2 := Phone{PhoneNo: "0987654321", Type: "Office"}
 
@@ -241,7 +263,7 @@ func TestSimpleMapType(t *testing.T) {
 	mapType["first"] = &phone1
 	mapType["second"] = &phone2
 
-	result := serilizeToMap(mapType, nil)
+	result := serilizeToMap(mapType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	firstPhone := make(map[string]interface{})
 	firstPhone["PhoneNo"] = "1234567890"

--- a/goastgen/libgoastgen_test.go
+++ b/goastgen/libgoastgen_test.go
@@ -76,11 +76,11 @@ type InterfaceStrObjPtrType struct {
 }
 
 func TestInterfaceObjPtrType(t *testing.T) {
-	lastNodeId = 1
-
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 	phone := Phone{PhoneNo: "1234567890", Type: "Home"}
 	interfaceObjPtrType := InterfaceStrObjPtrType{Id: 200, Phone: &phone}
-	result := serilizeToMap(interfaceObjPtrType, nil)
+	result := serilizeToMap(interfaceObjPtrType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 200
 	expectedResult["node_type"] = "goastgen.InterfaceStrObjPtrType"
@@ -96,11 +96,11 @@ func TestInterfaceObjPtrType(t *testing.T) {
 }
 
 func TestInterfaceStrPtrType(t *testing.T) {
-	lastNodeId = 1
-
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 	sampleStr := "Sample"
 	interfaceStrPtrType := InterfaceStrObjPtrType{Id: 100, Name: &sampleStr}
-	result := serilizeToMap(interfaceStrPtrType, nil)
+	result := serilizeToMap(interfaceStrPtrType, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 100
 	expectedResult["Name"] = "Sample"
@@ -110,15 +110,15 @@ func TestInterfaceStrPtrType(t *testing.T) {
 }
 
 func TestObjectWithNullValueCheck(t *testing.T) {
-	lastNodeId = 1
-
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 	type SimpleObj struct {
 		Id   int
 		Name *string
 	}
 
 	simpleObj := SimpleObj{Id: 10}
-	result := serilizeToMap(simpleObj, nil)
+	result := serilizeToMap(simpleObj, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Id"] = 10
 	expectedResult["node_type"] = "goastgen.SimpleObj"
@@ -126,14 +126,14 @@ func TestObjectWithNullValueCheck(t *testing.T) {
 	assert.Equal(t, expectedResult, result, "It should not process those fields which contains nil pointer, rest of the fields should be processed")
 
 	lastNodeId = 1
-
+	nodeAddressMap = make(map[uintptr]interface{})
 	type SimpleObjObj struct {
 		Id    int
 		Phone *Phone
 	}
 
 	simpleObjObj := SimpleObjObj{Id: 20}
-	result = serilizeToMap(simpleObjObj, nil)
+	result = serilizeToMap(simpleObjObj, nil, &lastNodeId, nodeAddressMap)
 	expectedResult = make(map[string]interface{})
 	expectedResult["Id"] = 20
 	expectedResult["node_type"] = "goastgen.SimpleObjObj"
@@ -141,13 +141,14 @@ func TestObjectWithNullValueCheck(t *testing.T) {
 	assert.Equal(t, expectedResult, result, "It should not process those fields which contains nil pointer, rest of the fields should be processed")
 
 	lastNodeId = 1
+	nodeAddressMap = make(map[uintptr]interface{})
 	type SimpleObjMap struct {
 		Id       int
 		Document *map[string]interface{}
 	}
 
 	simpleObjMap := SimpleObjObj{Id: 30}
-	result = serilizeToMap(simpleObjMap, nil)
+	result = serilizeToMap(simpleObjMap, nil, &lastNodeId, nodeAddressMap)
 	expectedResult = make(map[string]interface{})
 	expectedResult["Id"] = 30
 	expectedResult["node_type"] = "goastgen.SimpleObjObj"
@@ -155,6 +156,7 @@ func TestObjectWithNullValueCheck(t *testing.T) {
 	assert.Equal(t, expectedResult, result, "It should not process those fields which contains nil pointer, rest of the fields should be processed")
 
 	lastNodeId = 1
+	nodeAddressMap = make(map[uintptr]interface{})
 	type SimpleObjArray struct {
 		Id    int
 		Array *[2]string
@@ -162,7 +164,7 @@ func TestObjectWithNullValueCheck(t *testing.T) {
 	}
 
 	simpleObjArray := SimpleObjArray{Id: 40}
-	result = serilizeToMap(simpleObjArray, nil)
+	result = serilizeToMap(simpleObjArray, nil, &lastNodeId, nodeAddressMap)
 	expectedResult = make(map[string]interface{})
 	expectedResult["Id"] = 40
 	expectedResult["node_type"] = "goastgen.SimpleObjArray"
@@ -172,10 +174,10 @@ func TestObjectWithNullValueCheck(t *testing.T) {
 }
 
 func TestSimpleTypeWithNullValue(t *testing.T) {
-	lastNodeId = 1
-
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 	address := Address{Addone: "First line address"}
-	result := serilizeToMap(address, nil)
+	result := serilizeToMap(address, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Addone"] = "First line address"
 	expectedResult["node_type"] = "goastgen.Address"
@@ -183,8 +185,9 @@ func TestSimpleTypeWithNullValue(t *testing.T) {
 	assert.Equal(t, expectedResult, result, "Simple type result Map should match with expected result Map")
 
 	lastNodeId = 1
+	nodeAddressMap = make(map[uintptr]interface{})
 	phone := Phone{PhoneNo: "1234567890"}
-	result = serilizeToMap(phone, nil)
+	result = serilizeToMap(phone, nil, &lastNodeId, nodeAddressMap)
 	expectedResult = make(map[string]interface{})
 	expectedResult["PhoneNo"] = "1234567890"
 	expectedResult["Type"] = ""
@@ -194,10 +197,10 @@ func TestSimpleTypeWithNullValue(t *testing.T) {
 }
 
 func TestSimpleType(t *testing.T) {
-	lastNodeId = 1
-
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 	phone := Phone{PhoneNo: "1234567890", Type: "Home"}
-	result := serilizeToMap(phone, nil)
+	result := serilizeToMap(phone, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["PhoneNo"] = "1234567890"
 	expectedResult["Type"] = "Home"
@@ -207,12 +210,12 @@ func TestSimpleType(t *testing.T) {
 }
 
 func TestSimplePointerType(t *testing.T) {
-	lastNodeId = 1
-
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 	addtwo := "Second line address"
 	var p *Address
 	p = &Address{Addone: "First line address", Addtwo: &addtwo}
-	result := serilizeToMap(p, nil)
+	result := serilizeToMap(p, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Addone"] = "First line address"
 	expectedResult["Addtwo"] = "Second line address"
@@ -223,15 +226,15 @@ func TestSimplePointerType(t *testing.T) {
 }
 
 func TestSecondLevelType(t *testing.T) {
-	lastNodeId = 1
-
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 	addtwo := "Second line address"
 	var a *Address
 	a = &Address{Addone: "First line address", Addtwo: &addtwo}
 
 	var p *Person
 	p = &Person{Name: "Sample Name", Address: a}
-	result := serilizeToMap(p, nil)
+	result := serilizeToMap(p, nil, &lastNodeId, nodeAddressMap)
 	expectedResult := make(map[string]interface{})
 	expectedResult["Name"] = "Sample Name"
 	expectedResult["node_type"] = "goastgen.Person"
@@ -247,40 +250,44 @@ func TestSecondLevelType(t *testing.T) {
 }
 
 func TestSimplePrimitive(t *testing.T) {
-	result := serilizeToMap("Hello", nil)
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
+	result := serilizeToMap("Hello", nil, &lastNodeId, nodeAddressMap)
 	assert.Equal(t, "Hello", result, "Simple string test should return same value")
 
 	message := "Hello another message"
-	result = serilizeToMap(&message, nil)
+	result = serilizeToMap(&message, nil, &lastNodeId, nodeAddressMap)
 
 	assert.Equal(t, "Hello another message", result, "Simple string pointer test should return same value string")
 }
 
 func TestSimpleNullCheck(t *testing.T) {
+	lastNodeId := 1
+	var nodeAddressMap = make(map[uintptr]interface{})
 	var emptyStr string
 
-	result := serilizeToMap(emptyStr, nil)
+	result := serilizeToMap(emptyStr, nil, &lastNodeId, nodeAddressMap)
 	assert.Equal(t, "", result, "result should be empty string")
 
 	var nilValue *string = nil
-	nilResult := serilizeToMap(nilValue, nil)
+	nilResult := serilizeToMap(nilValue, nil, &lastNodeId, nodeAddressMap)
 	assert.Nil(t, nilResult, "Null value should return null")
 
 	var nillObj *Phone
 
-	nilResult = serilizeToMap(nillObj, nil)
+	nilResult = serilizeToMap(nillObj, nil, &lastNodeId, nodeAddressMap)
 	assert.Nil(t, nilResult, "Null object should return null")
 
 	var nillMap *map[string]interface{}
-	nilResult = serilizeToMap(nillMap, nil)
+	nilResult = serilizeToMap(nillMap, nil, &lastNodeId, nodeAddressMap)
 	assert.Nil(t, nilResult, "Null map should return null")
 
 	var nilSlice *[]string
-	nilResult = serilizeToMap(nilSlice, nil)
+	nilResult = serilizeToMap(nilSlice, nil, &lastNodeId, nodeAddressMap)
 	assert.Nil(t, nilResult, "Null Slice should return null")
 
 	var nilArray *[2]string
-	nilResult = serilizeToMap(nilArray, nil)
+	nilResult = serilizeToMap(nilArray, nil, &lastNodeId, nodeAddressMap)
 	assert.Nil(t, nilResult, "Null Array should return null")
 
 }


### PR DESCRIPTION
1. As we were maintaining global cache of processed references. It was colliding with objects across files, hence the nodes which were processed for one file's ast, was getting just referenced with id from other file. Made changes to intialise the cache before every file is being processed.
2. Updated respective test cases.