### PR TITLE
Support for exclude file

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"privado.ai/goastgen/goastgen"
+	"regexp"
 	"runtime"
 	"strings"
 )
@@ -14,8 +15,8 @@ import (
 var Version = "dev"
 
 func main() {
-	out, inputPath := parseArguments()
-	processRequest(out, inputPath)
+	out, inputPath, excludeFiles := parseArguments()
+	processRequest(out, inputPath, excludeFiles)
 }
 
 func processFile(out string, inputPath string, path string, info os.FileInfo, resultErr chan error, sem chan int) {
@@ -50,7 +51,7 @@ func processFile(out string, inputPath string, path string, info os.FileInfo, re
 	resultErr <- err
 }
 
-func processRequest(out string, inputPath string) {
+func processRequest(out string, inputPath string, excludeFiles string) {
 	if strings.HasSuffix(inputPath, ".go") {
 		fileInfo, err := os.Stat(inputPath)
 		if err != nil {
@@ -94,8 +95,11 @@ func processRequest(out string, inputPath string) {
 				return err
 			}
 			if !info.IsDir() && (strings.HasSuffix(info.Name(), ".go") || strings.HasSuffix(info.Name(), ".mod")) {
-				totalSentForProcessing++
-				go processFile(out, inputPath, path, info, resultErrChan, sem)
+				matched, _ := regexp.MatchString(excludeFiles, info.Name())
+				if matched == false {
+					totalSentForProcessing++
+					go processFile(out, inputPath, path, info, resultErrChan, sem)
+				}
 			}
 			return nil
 		})
@@ -118,16 +122,18 @@ func processRequest(out string, inputPath string) {
 	}
 }
 
-func parseArguments() (string, string) {
+func parseArguments() (string, string, string) {
 	var (
-		out       string
-		inputPath string = ""
-		version   bool
-		help      bool
+		out          string
+		inputPath    string = ""
+		version      bool
+		help         bool
+		excludeFiles string
 	)
 	flag.StringVar(&out, "out", ".ast", "Out put location of ast")
 	flag.BoolVar(&version, "version", false, "print the version")
 	flag.BoolVar(&help, "help", false, "print the usage")
+	flag.StringVar(&excludeFiles, "exclude", "", "regex to exclude files")
 	flag.Parse()
 	if version {
 		fmt.Println(Version)
@@ -146,7 +152,7 @@ func parseArguments() (string, string) {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
-	return out, inputPath
+	return out, inputPath, excludeFiles
 }
 
 func writeFileContents(location string, contents string) error {

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func processRequest(out string, inputPath string, excludeFiles string) {
 			}
 			if !info.IsDir() && (strings.HasSuffix(info.Name(), ".go") || strings.HasSuffix(info.Name(), ".mod")) {
 				matched, _ := regexp.MatchString(excludeFiles, info.Name())
-				if matched == false {
+				if excludeFiles == "" || matched == false {
 					totalSentForProcessing++
 					go processFile(out, inputPath, path, info, resultErrChan, sem)
 				}

--- a/main_test.go
+++ b/main_test.go
@@ -32,13 +32,13 @@ func TestProcessRequestWithSingleFileUseCase(t *testing.T) {
 		"fmt.Println(\"Hello World\")\n" +
 		"}"
 	file.WriteString(code)
-	processRequest(".ast", srcFile)
+	processRequest(".ast", srcFile, "")
 	expectedJsonFileLocation := filepath.Join(newFolder, ".ast", "hello.go.json")
 	_, err = os.Stat(expectedJsonFileLocation)
 	assert.Nil(t, err, "check the ast output is generated at expected location")
 
 	diffOutLocation := filepath.Join(tempDir, uuid.New().String())
-	processRequest(diffOutLocation, srcFile)
+	processRequest(diffOutLocation, srcFile, "")
 	expectedJsonFileLocation = filepath.Join(diffOutLocation, "hello.go.json")
 	_, err = os.Stat(expectedJsonFileLocation)
 	assert.Nil(t, err, "check the ast output is generated at expected location")
@@ -80,7 +80,7 @@ func TestProcessRequestWithMultipleFileDiffFolderStructureUsecase(t *testing.T) 
 		return
 	}
 	file.WriteString(code)
-	processRequest(".ast", newFolder)
+	processRequest(".ast", newFolder, "")
 	expectedJsonFileLocationone := filepath.Join(newFolder, ".ast", "hello.go.json")
 	_, err = os.Stat(expectedJsonFileLocationone)
 	assert.Nil(t, err, "check the ast output is generated at expected location")
@@ -89,7 +89,7 @@ func TestProcessRequestWithMultipleFileDiffFolderStructureUsecase(t *testing.T) 
 	assert.Nil(t, err, "check the ast output is generated at expected location")
 
 	diffOutLocation := filepath.Join(tempDir, uuid.New().String())
-	processRequest(diffOutLocation, newFolder)
+	processRequest(diffOutLocation, newFolder, "")
 	expectedJsonFileLocationone = filepath.Join(diffOutLocation, "hello.go.json")
 	_, err = os.Stat(expectedJsonFileLocationone)
 	assert.Nil(t, err, "check the ast output is generated at expected location")


### PR DESCRIPTION
Added support to exclude file file, use `./goastgen -exclude "regex" scan_dir`